### PR TITLE
Migrate to Python 3

### DIFF
--- a/jdwp-shellifier.py
+++ b/jdwp-shellifier.py
@@ -100,7 +100,7 @@ class JDWPClient:
             if errcode :
                 raise Exception("Received errcode %d" % errcode)
 
-        buf = ""
+        buf = b""
         while len(buf) + 11 < pktlen:
             data = self.socket.recv(1024)
             if len(data):
@@ -361,7 +361,7 @@ class JDWPClient:
         if len(buf):
             return self.readstring(buf)
         else:
-            return ""
+            return b""
 
     def query_thread(self, threadId, kind):
         data = self.format(self.objectIDSize, threadId)

--- a/jdwp-shellifier.py
+++ b/jdwp-shellifier.py
@@ -134,10 +134,10 @@ class JDWPClient:
                     data[name] = buf[index+4:index+4+l]
                     index += 4+l
                 elif fmt == 'C':
-                    data[name] = ord(struct.unpack(">c", buf[index])[0])
+                    data[name] = struct.unpack(">B", buf[index])[0]
                     index += 1
                 elif fmt == 'Z':
-                    t = ord(struct.unpack(">c", buf[index])[0])
+                    t = struct.unpack(">B", buf[index])[0]
                     if t == 115:
                         s = self.solve_string(buf[index+1:index+9])
                         data[name] = s


### PR DESCRIPTION
Greetings, jdwp-shellifier will still happily hand over shell in 2021 although Python 2 is getting harder to find.  I managed to get system info and commands executed under Python 3.9 and while breaking on default java.net.ServerSocket.accept method.